### PR TITLE
feat: usersテーブル、Userモデル修正

### DIFF
--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**
@@ -41,4 +42,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function attendances()
+    {
+        return $this->hasMany(Attendance::class);
+    }
 }

--- a/src/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/src/database/migrations/2014_10_12_000000_create_users_table.php
@@ -19,6 +19,7 @@ class CreateUsersTable extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->enum('role', ['admin', 'user'])->default('user');
             $table->rememberToken();
             $table->timestamps();
         });


### PR DESCRIPTION
## 📝 概要
`users` テーブルに `role` カラムを追加し、ユーザーごとに権限（admin / user）を管理できるようにしました。  
また、`User` モデルに `attendances` とのリレーションを追加しました。

## 🔧 変更内容
- `users` テーブルに `role` カラム（enum型）を追加（デフォルトは `'user'`）
- `User` モデルに `attendances()` メソッドを追加（`hasMany` リレーション）

## 📝 補足
- `role` は `enum` 型で `'admin'` または `'user'` のみ許可しています。
- `Attendance` モデルとのリレーションにより、ユーザーごとに勤怠データを参照できます。
