### PR TITLE
fix: rename attendance table to attendances

### DIFF
--- a/src/database/migrations/2025_03_21_233047_create_attendances_table.php
+++ b/src/database/migrations/2025_03_21_233047_create_attendances_table.php
@@ -13,7 +13,7 @@ class CreateAttendancesTable extends Migration
      */
     public function up()
     {
-        Schema::create('attendance', function (Blueprint $table) {
+        Schema::create('attendances', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
             $table->date('date'); // 勤務日


### PR DESCRIPTION
- 単数形 `attendance` を複数形 `attendances` に修正
- Laravelの命名規則（テーブルは複数形）に準拠
- 外部キー制約が正常に機能するよう調整